### PR TITLE
Closes #57 - Submitting a blank submission causes failures

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -3,6 +3,7 @@ class Submission < ApplicationRecord
   has_many :anecdotes
   has_many :researches
   validate :double_submit_same_illness
+  validates :illness_id, presence: true
   before_save :geocode_location
   before_save :active_installation
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Submission, type: :model do
 
   it { is_expected.to have_many(:researches) }
   it { is_expected.to have_many(:anecdotes) }
+  it { validate_presence_of :illness_id }
 
   describe 'active_installation' do
     it 'is active' do


### PR DESCRIPTION
Closes #57 by adding validation on illness_id. 