### PR TITLE
Restrict new Admin signups for RailsAdmin via Devise

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,0 +1,17 @@
+%h2 Log in
+= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .field
+    = f.label :password
+    %br/
+    = f.password_field :password, autocomplete: "off"
+  - if devise_mapping.rememberable?
+    .field
+      = f.check_box :remember_me
+      = f.label :remember_me
+  .actions
+    = f.submit "Log in"
+= render "devise/shared/links"

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,0 +1,3 @@
+- if controller_name != 'sessions'
+  = link_to "Log in", new_session_path(resource_name)
+  %br/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, skip: [:registrations]
 
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   resources :installations, only: [:index, :show]


### PR DESCRIPTION
* Removes the sign up link at /admin 
* Removes the registration routes